### PR TITLE
Added support for Nitro Enclaves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,6 +306,9 @@ name = "ring"
 untrusted = "0.7.0"
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
+nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
+nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
+
 [target.'cfg(all(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86", target_arch = "x86_64"), not(target_os = "ios")))'.dependencies]
 spin = { version = "0.5.2", default-features = false }
 
@@ -346,6 +349,7 @@ std = ["alloc"]
 test_logging = []
 mesalock_sgx = ["std", "sgx_tstd", "alloc"]
 non_sgx = ["libc", "web-sys", "winapi" ]
+nitro = ["nsm_lib", "nsm_io"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,20 +63,24 @@
     //warnings
 )]
 #![cfg_attr(
-    any(
-        target_os = "redox",
         all(
-            not(test),
-            not(feature = "use_heap"),
-            unix,
-            not(any(target_os = "macos", target_os = "ios")),
-            any(not(target_os = "linux"), feature = "dev_urandom_fallback")
-        ),
-        all(
-            feature = "mesalock_sgx",
-            not(target_env = "sgx"),
-        ),
-    ),
+            any(
+                target_os = "redox",
+                all(
+                    not(test),
+                    not(feature = "use_heap"),
+                    unix,
+                    not(any(target_os = "macos", target_os = "ios")),
+                    any(not(target_os = "linux"), feature = "dev_urandom_fallback")
+                ),
+                all(
+                    feature = "mesalock_sgx",
+                    not(target_env = "sgx"),
+                )
+            ),
+            not(feature = "nitro")
+        )
+    ,
     no_std
 )]
 #![cfg_attr(feature = "internal_benches", allow(unstable_features), feature(test))]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -469,7 +469,6 @@ mod nitro {
             },
             _ => return Err(error::Unspecified),
         };
-        Ok(())
     }
 }
 


### PR DESCRIPTION
In AWS Nitro enclaves, there is not enough entropy in /dev/urandom to pull with out warning messages, and sysrand doesn't work.
AWS has implemented a different mechanism for generating random numbers.

I've added support in rand.rs for this mechanism. I've also added a "feature" to enable it, as whether a binary is intended for Nitro Enclaves is otherwise not detectable.