### PR TITLE
Add support for IceCap

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -172,6 +172,7 @@ pub(crate) mod arm {
         #[cfg_attr(
             any(
                 target_os = "ios",
+                target_os = "icecap",
                 not(any(target_arch = "arm", target_arch = "aarch64"))
             ),
             allow(dead_code)
@@ -202,7 +203,7 @@ pub(crate) mod arm {
             {
                 return false;
             }
-            #[cfg(target_os = "optee")]
+            #[cfg(any(target_os = "optee", target_os = "icecap"))]
             {
                 return false;
             }
@@ -211,6 +212,7 @@ pub(crate) mod arm {
 
     // Keep in sync with `ARMV7_NEON`.
     #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg_attr(target_os = "icecap", allow(dead_code))]
     pub(crate) const NEON: Feature = Feature {
         mask: 1 << 0,
         ios: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ extern crate sgx_tstd as std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(all(target_arch = "aarch64", not(target_os="optee")))]
+#[cfg(all(target_arch = "aarch64", not(target_os="optee"), not(target_os = "icecap")))]
 extern crate libc;
 
 #[macro_use]


### PR DESCRIPTION
This PR adds basic support for [IceCap](https://gitlab.com/arm-research/security/icecap/icecap).

The IceCap platform does not yet offer a random number generation API to realms, so the random number generation implemented in this PR is just a placeholder.

This PR accompanies veracruz-project/veracruz#149.