### PR TITLE
Make changes required by changes in aws-nitro-enclaves-nsm-api.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,7 @@ untrusted = "0.7.0"
 sgx_tstd = { rev = "v1.1.2", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 nsm_lib = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="nsm-lib", optional = true }
-nsm_io =  { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package = "nsm-io", optional = true }
+nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", branch = "main", package="aws-nitro-enclaves-nsm-api", optional = true }
 
 [target.'cfg(all(any(target_arch = "aarch64", target_arch = "arm", target_arch = "x86", target_arch = "x86_64"), not(target_os = "ios")))'.dependencies]
 spin = { version = "0.5.2", default-features = false }
@@ -349,7 +349,7 @@ std = ["alloc"]
 test_logging = []
 mesalock_sgx = ["std", "sgx_tstd", "alloc"]
 non_sgx = ["libc", "web-sys", "winapi" ]
-nitro = ["nsm_lib", "nsm_io"]
+nitro = ["nsm_lib", "nsm_api"]
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -26,7 +26,7 @@
 //! documentation for more details.
 
 #[cfg(feature = "nitro")]
-use nsm_io;
+use nsm_api;
 #[cfg(feature = "nitro")]
 use nsm_lib;
 
@@ -467,7 +467,7 @@ mod nitro {
             nsm_lib::nsm_get_random(nsm_fd, dest.as_mut_ptr(), &mut dest_len)
         };
         return match status {
-            nsm_io::ErrorCode::Success => {
+            nsm_api::api::ErrorCode::Success => {
                 Ok(())
             },
             _ => return Err(error::Unspecified),


### PR DESCRIPTION
They have reorganised the subcrates into modules.